### PR TITLE
Add startCommand to railway.json to force load_corpora execution

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -4,6 +4,7 @@
     "builder": "NIXPACKS"
   },
   "deploy": {
+    "startCommand": "python manage.py migrate && python manage.py load_corpora --verbosity=2 && gunicorn jubjub.wsgi:application --bind 0.0.0.0:$PORT",
     "restartPolicyType": "ON_FAILURE",
     "restartPolicyMaxRetries": 10
   }


### PR DESCRIPTION
Railway was ignoring nixpacks.toml. Using railway.json startCommand to explicitly run load_corpora during deployment.